### PR TITLE
Don't execute blocking operations on the server thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib
 .idea
+*.iml
 target

--- a/src/main/java/dev/nicho/rolesync/db/DatabaseHandler.java
+++ b/src/main/java/dev/nicho/rolesync/db/DatabaseHandler.java
@@ -1,5 +1,6 @@
 package dev.nicho.rolesync.db;
 
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.security.SecureRandom;
@@ -80,6 +81,8 @@ public abstract class DatabaseHandler {
      * @throws SQLException if an SQL error occurs
      */
     public int getLinkedUserCount() throws SQLException {
+        checkAsync();
+
         Connection c = this.getConnection();
         PreparedStatement ps = c.prepareStatement("SELECT COUNT(*) FROM "
                 + plugin.getConfig().getString("database.tablePrefix") + "_discordmcusers");
@@ -101,6 +104,8 @@ public abstract class DatabaseHandler {
      * @throws SQLException if an SQL error occurs
      */
     public void linkUser(String discordID, String minecraftUUID) throws SQLException {
+        checkAsync();
+
         Connection c = this.getConnection();
         PreparedStatement ps = c.prepareStatement(
                 "INSERT INTO " + plugin.getConfig().getString("database.tablePrefix") +
@@ -126,6 +131,8 @@ public abstract class DatabaseHandler {
      * @throws SQLException if an SQL error occurs
      */
     public void addToWhitelist(String uuid) throws SQLException {
+        checkAsync();
+
         Connection c = this.getConnection();
         PreparedStatement ps = c.prepareStatement(
                 "UPDATE " + plugin.getConfig().getString("database.tablePrefix") + "_discordmcusers " +
@@ -145,6 +152,8 @@ public abstract class DatabaseHandler {
      * @throws SQLException if an SQL error occurs
      */
     public void removeFromWhitelist(String uuid) throws SQLException {
+        checkAsync();
+
         Connection c = this.getConnection();
         PreparedStatement ps = c.prepareStatement(
                 "UPDATE " + plugin.getConfig().getString("database.tablePrefix") + "_discordmcusers " +
@@ -164,6 +173,8 @@ public abstract class DatabaseHandler {
      * @throws SQLException if an SQL error occurs
      */
     public void unlink(String uuid) throws SQLException {
+        checkAsync();
+
         Connection c = this.getConnection();
         PreparedStatement ps = c.prepareStatement("DELETE FROM "
                 + plugin.getConfig().getString("database.tablePrefix") + "_discordmcusers WHERE minecraft_uuid = ?");
@@ -184,6 +195,8 @@ public abstract class DatabaseHandler {
      * @throws SQLException if an SQL error occurs
      */
     public void forAllLinkedUsers(Consumer<LinkedUserInfo> callback) throws SQLException {
+        checkAsync();
+
         Connection c = this.getConnection();
         PreparedStatement ps = c.prepareStatement("SELECT discord_id, minecraft_uuid, whitelisted, verification_code, verified, username_when_linked FROM "
                 + plugin.getConfig().getString("database.tablePrefix") + "_discordmcusers");
@@ -211,6 +224,8 @@ public abstract class DatabaseHandler {
      * @throws SQLException if an SQL error occurs
      */
     public LinkedUserInfo getLinkedUserInfo(String identifier) throws SQLException {
+        checkAsync();
+
         Connection c = this.getConnection();
         PreparedStatement ps = c.prepareStatement("SELECT discord_id, minecraft_uuid, whitelisted, verification_code, verified, username_when_linked FROM "
                 + plugin.getConfig().getString("database.tablePrefix") + "_discordmcusers "
@@ -339,6 +354,12 @@ public abstract class DatabaseHandler {
         }
 
         return migrated;
+    }
+
+    private final void checkAsync() {
+        if (Bukkit.isPrimaryThread()) {
+            throw new IllegalStateException("Attempted to execute a database operation from the server thread!");
+        }
     }
 
     /**

--- a/src/main/java/dev/nicho/rolesync/listeners/PlayerJoinListener.java
+++ b/src/main/java/dev/nicho/rolesync/listeners/PlayerJoinListener.java
@@ -1,6 +1,5 @@
 package dev.nicho.rolesync.listeners;
 
-import dev.nicho.rolesync.util.MojangAPI;
 import dev.nicho.rolesync.util.Util;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -8,14 +7,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.json.JSONArray;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Scanner;
 
 public class PlayerJoinListener implements Listener {
 
@@ -30,24 +23,26 @@ public class PlayerJoinListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         if (event.getPlayer().hasPermission("discordrolesync.notifyupdates")) {
-            // check for updates and send if available
-            String version = plugin.getDescription().getVersion();
-            String latestVersion;
-            try {
-                latestVersion = Util.getLatestVersion();
-            } catch (IOException e) {
-                e.printStackTrace();
+            plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+                // check for updates and send if available
+                String version = plugin.getDescription().getVersion();
+                String latestVersion;
+                try {
+                    latestVersion = Util.getLatestVersion();
+                } catch (IOException e) {
+                    e.printStackTrace();
 
-                return;
-            }
+                    return;
+                }
 
-            if (!latestVersion.equalsIgnoreCase(version)) {
-                String message = ChatColor.BLUE + "[DRS] " + ChatColor.AQUA + lang.getString("notLatestVersion") + "\n" +
-                        ChatColor.BLUE + "[DRS] " + ChatColor.AQUA + lang.getString("current") + " " + ChatColor.RED + version + ChatColor.AQUA + "\n" +
-                        ChatColor.BLUE + "[DRS] " + ChatColor.AQUA + lang.getString("latest") + " " + ChatColor.GREEN + latestVersion;
+                if (!latestVersion.equalsIgnoreCase(version)) {
+                    String message = ChatColor.BLUE + "[DRS] " + ChatColor.AQUA + lang.getString("notLatestVersion") + "\n" +
+                            ChatColor.BLUE + "[DRS] " + ChatColor.AQUA + lang.getString("current") + " " + ChatColor.RED + version + ChatColor.AQUA + "\n" +
+                            ChatColor.BLUE + "[DRS] " + ChatColor.AQUA + lang.getString("latest") + " " + ChatColor.GREEN + latestVersion;
 
-                event.getPlayer().sendMessage(message);
-            }
+                    event.getPlayer().sendMessage(message);
+                }
+            });
         }
     }
 }

--- a/src/main/java/dev/nicho/rolesync/listeners/WhitelistLoginListener.java
+++ b/src/main/java/dev/nicho/rolesync/listeners/WhitelistLoginListener.java
@@ -6,7 +6,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.sql.SQLException;
@@ -23,13 +23,13 @@ public class WhitelistLoginListener implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler (priority = EventPriority.HIGHEST)
-    public void onPlayerLogin(PlayerLoginEvent event) {
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerLogin(AsyncPlayerPreLoginEvent event) {
         DatabaseHandler.LinkedUserInfo usrInfo;
         try {
-            usrInfo = db.getLinkedUserInfo(event.getPlayer().getUniqueId().toString());
+            usrInfo = db.getLinkedUserInfo(event.getUniqueId().toString());
         } catch (SQLException e) {
-            event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, lang.getString("whitelistErrorKickMsg"));
+            event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_WHITELIST, lang.getString("whitelistErrorKickMsg"));
             plugin.getLogger().severe("Error while checking if a user is whitelisted. Please check the stack trace below and contact the developer if needed.");
             e.printStackTrace();
 
@@ -38,13 +38,13 @@ public class WhitelistLoginListener implements Listener {
 
         if (usrInfo == null) {
             // user not linked
-            event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, lang.getString("pleaseLink")
+            event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_WHITELIST, lang.getString("pleaseLink")
                     + " " + plugin.getConfig().getString("discordUrl"));
         } else if (plugin.getConfig().getBoolean("requireVerification") && !usrInfo.verified) {
-            event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, lang.getString("whitelistNotVerifiedKickMsg")
+            event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_WHITELIST, lang.getString("whitelistNotVerifiedKickMsg")
                     + " " + ChatColor.AQUA + usrInfo.code);
         } else if (!usrInfo.whitelisted) {
-            event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, lang.getString("notWhitelistedKickMsg"));
+            event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_WHITELIST, lang.getString("notWhitelistedKickMsg"));
         }
     }
 }


### PR DESCRIPTION
Hey, thanks for the plugin! It saved me a fair bit of time 👍 

I'm making a few changes to my fork to resolve some issues, and this is the first of those changes.

These changes ensure that blocking, or potentially blocking, operations are always executed on a thread other than the main server thread. Executing blocking operations on the main server thread will cause noticeable lag issues.